### PR TITLE
Styling adjustments

### DIFF
--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -103,11 +103,16 @@ export default React.memo(styled(Apps)`
   height: 100vh;
 
   &.theme--default {
+    .apps--SideBar-Item,
+    .apps--SideBar-Item:not(:last-child) {
+      margin-bottom: 0;
+    }
+
     a.apps--SideBar-Item-NavLink {
       border-radius: 0.25rem;
       color: var(--grey70);
       display: block;
-      margin: 0 0 0.24rem;
+      margin: 0 0 0.75rem;
       padding: 0.5rem 0.5rem;
       white-space: nowrap;
 
@@ -116,7 +121,7 @@ export default React.memo(styled(Apps)`
       }
 
       &:hover {
-        background: var(--grey20);
+        background: var(--grey30);
         border-radius: var(--btn-radius-default);
         color: var(--grey80);
       }

--- a/packages/apps/src/Apps.tsx
+++ b/packages/apps/src/Apps.tsx
@@ -110,7 +110,7 @@ export default React.memo(styled(Apps)`
 
     a.apps--SideBar-Item-NavLink {
       border-radius: 0.25rem;
-      color: var(--grey70);
+      color: var(--grey60);
       display: block;
       margin: 0 0 0.75rem;
       padding: 0.5rem 0.5rem;

--- a/packages/apps/src/HelpWidget.tsx
+++ b/packages/apps/src/HelpWidget.tsx
@@ -98,7 +98,6 @@ export default styled(HelpWidget)`
         width: 100%;
         padding: 8px 12px;
         color: var(--grey80);
-        transition: background 120ms ease-in 0s;
         &:hover {
           background: var(--grey40);
           color: var(--grey80);

--- a/packages/apps/src/SideBar/Settings.tsx
+++ b/packages/apps/src/SideBar/Settings.tsx
@@ -74,6 +74,10 @@ export default React.memo(styled(Settings)`
         color: var(--grey80);
       }
 
+      &:focus {
+        border-color: transparent;
+      }
+
       &.active {
         background: transparent;
         border-color: transparent;

--- a/packages/react-components/src/FileSupplied.tsx
+++ b/packages/react-components/src/FileSupplied.tsx
@@ -74,7 +74,7 @@ export default React.memo(styled(FileSupplied)`
     height: 100%;
 
     &:hover {
-      color: var(--grey90);
+      color: var(--grey80);
     }
   }
 

--- a/packages/react-components/src/InputAddress/index.tsx
+++ b/packages/react-components/src/InputAddress/index.tsx
@@ -299,10 +299,22 @@ const ExportedComponent = withMulti(
       pointer-events: all;
     }
 
-    .ui.search.selection.dropdown {
-      &:not(.disabled) {
-        height: 4.25rem;
+    .ui.selection.dropdown {
+      padding: 0.75rem;
+
+      >input.search {
+        padding: 0.75rem;
       }
+
+      >.dropdown.icon {
+        top: auto;
+      }
+    }
+
+    .ui.search.selection.dropdown {
+      display: flex;
+      align-items: center;
+      justify-content: center;
 
       > .text > .ui--KeyPair {
         .ui--IdentityIcon-Outer {

--- a/packages/react-components/src/InputFile.tsx
+++ b/packages/react-components/src/InputFile.tsx
@@ -163,7 +163,7 @@ function InputFile ({ accept, children, className = '', clearContent, convertHex
 export default React.memo(styled(InputFile)`
   cursor: pointer;
   display: table;
-  font-size: 1rem;
+  font-size: 0.875rem;
   margin: 0.25rem 0;
   padding: 1rem;
 

--- a/packages/react-components/src/InputFile.tsx
+++ b/packages/react-components/src/InputFile.tsx
@@ -192,6 +192,11 @@ export default React.memo(styled(InputFile)`
     cursor: pointer;
   }
 
+  &:focus {
+    outline: 0;
+    border: 2px solid var(--blue-primary);
+  }
+
   .children {
     margin-top: 1.5rem;
   }

--- a/packages/react-components/src/LabelHelp.tsx
+++ b/packages/react-components/src/LabelHelp.tsx
@@ -46,4 +46,5 @@ export default React.memo(styled(LabelHelp)`
   display: inline-block;
   line-height: 1rem;
   margin: 0 0 0 0.25rem;
+  color: var(--grey50);
 `);

--- a/packages/react-components/src/Status/index.tsx
+++ b/packages/react-components/src/Status/index.tsx
@@ -186,17 +186,17 @@ function Status ({ className = '', stqueue, txqueue }: Props): React.ReactElemen
   return (
     <div className={`ui--Status ${className}`}>
       {/* {(allSt.length + completedTx.length) > 1 && ( */
-      false && (
-        <div className='dismiss'>
-          <Button
-            icon='cancel'
-            isFluid
-            isPrimary
-            label={t<string>('Dismiss all notifications')}
-            onClick={_onDismiss}
-          />
-        </div>
-      )}
+        false && (
+          <div className='dismiss'>
+            <Button
+              icon='cancel'
+              isFluid
+              isPrimary
+              label={t<string>('Dismiss all notifications')}
+              onClick={_onDismiss}
+            />
+          </div>
+        )}
       {allTx.map(renderItem)}
       {allSt.map(renderStatus)}
     </div>
@@ -284,7 +284,7 @@ export default React.memo(styled(Status)`
         cursor: pointer;
 
         &:hover {
-          color: var(--grey90);
+          color: var(--grey80);
         }
       }
     }

--- a/packages/react-components/src/styles/components.ts
+++ b/packages/react-components/src/styles/components.ts
@@ -17,7 +17,7 @@ export default css`
 
     &.error {
       background: #fff6f6;
-      border-color: #e0b4b4;
+      border-color: var(--red-primary);
     }
 
     &.monospace {

--- a/packages/react-components/src/styles/constants.ts
+++ b/packages/react-components/src/styles/constants.ts
@@ -16,7 +16,7 @@ export const SECONDARY_LIGHT_HEX = '#F8C34F';
 
 export const ERROR_BG_HEX = '#431818';
 
-export const ERROR_FOCUS_HEX = '#bc0000';
+export const ERROR_FOCUS_HEX = 'var(--red-primary)';
 
 export const ELEV_CSS = `
   box-sizing: border-box;

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -106,7 +106,7 @@ export default createGlobalStyle<Props>`
   }
 
   #root {
-    color: var(--grey90);
+    color: var(--grey80);
     font-family: var(--default-font-family, sans-serif);
     font-size: 0.875rem;
     height: 100%;
@@ -232,7 +232,7 @@ export default createGlobalStyle<Props>`
   }
 
   h1, h2, h3, h4, h5 {
-    color: var(--grey90);
+    color: var(--grey80);
     font-family: var(--default-font-family, sans-serif);
     font-weight: 300;
   }
@@ -253,7 +253,7 @@ export default createGlobalStyle<Props>`
   header {
     margin: 2rem 0;
     padding: 0 0 2rem;
-    border-bottom: 1px solid var(--grey20);
+    border-bottom: 1px solid var(--grey30);
 
     > article {
       background: transparent;
@@ -265,12 +265,12 @@ export default createGlobalStyle<Props>`
   }
 
   input {
-    color: var(--grey90);
+    color: var(--grey80);
   }
 
   label {
     box-sizing: border-box;
-    color: var(--grey90);
+    color: var(--grey80);
     display: block;
     font-family: var(--default-font-family, sans-serif);
     font-size: 1rem;

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -106,7 +106,7 @@ export default createGlobalStyle<Props>`
   }
 
   #root {
-    color: var(--grey80);
+    color: var(--grey60);
     font-family: var(--default-font-family, sans-serif);
     font-size: 0.875rem;
     height: 100%;

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -168,8 +168,8 @@ export default createGlobalStyle<Props>`
 
     &.error {
       background: #fff6f6;
-      border-color: #e0b4b4;
-      color: #9f3a38;
+      border-color: var(--red-primary);
+      color: var(--grey60);
     }
 
     &.padded {

--- a/packages/react-components/src/styles/semantic.ts
+++ b/packages/react-components/src/styles/semantic.ts
@@ -44,15 +44,11 @@ export default css`
     width: 100%;
   }
 
-  .ui.dropdown,
-  .ui.input {
-    margin: 0.25rem 0;
-  }
-
   .ui.input {
     > input, > input:focus {
       color: var(--grey80);
       ${ELEV_2_CSS}
+      font-family: var(--default-font-family, sans-serif);
     }
 
     > input:focus {

--- a/packages/react-components/src/styles/semantic.ts
+++ b/packages/react-components/src/styles/semantic.ts
@@ -51,7 +51,7 @@ export default css`
 
   .ui.input {
     > input, > input:focus {
-      color: var(--grey90);
+      color: var(--grey80);
       ${ELEV_2_CSS}
     }
 
@@ -69,7 +69,7 @@ export default css`
 
   .ui.selection.dropdown {
     ${ELEV_2_CSS}
-    color: var(--grey90);
+    color: var(--grey80);
     border: 1px solid var(--grey20); 
   }
 
@@ -110,7 +110,7 @@ export default css`
   }
 
   .ui.dropdown .menu > .header {
-    color: var(--grey90);
+    color: var(--grey80);
   }
 
   .ui.selection.active.dropdown {
@@ -126,13 +126,13 @@ export default css`
   }
 
   .ui.selection.visible.dropdown>.text:not(.default) {
-    color: var(--grey90);
+    color: var(--grey80);
   }
 
   .ui.selection.dropdown .menu > .item {
     &, &:hover {
       border-top: 0;
-      color: var(--grey90);
+      color: var(--grey80);
     }
 
     &:hover {
@@ -141,7 +141,7 @@ export default css`
   }
 
   .ui.dropdown .menu .selected.item {
-    color: var(--grey90);
+    color: var(--grey80);
   }
 
   // .ui.dropdown .menu > .item.header.disabled:hover,

--- a/packages/react-components/src/styles/semantic.ts
+++ b/packages/react-components/src/styles/semantic.ts
@@ -61,8 +61,15 @@ export default css`
 
     &.error {
       > input {
-        background: ${ERROR_BG_HEX};
+        background: var(--grey20);
         border: 1px solid ${ERROR_FOCUS_HEX};
+
+        :focus,
+        ::placeholder,
+        ::-webkit-input-placeholder,
+        :focus::-webkit-input-placeholder {
+          color: var(--grey60) !important;
+        }
       }
     }
   }
@@ -175,7 +182,7 @@ export default css`
 
     &.disabled.error input {
       background-color: #fff6f6;
-      border-color: #e0b4b4;
+      border-color: var(--red-primary);
     }
 
     > input {

--- a/packages/react-components/src/styles/theme.ts
+++ b/packages/react-components/src/styles/theme.ts
@@ -15,8 +15,8 @@ export default css`
     --blue-primary: #2477B3;
     --blue-secondary: #195580;
     --green-primary: #16DB9A;
-    --red-primary: #bc0000;
-    --red-secondary: #431818;
+    --red-primary: #F54E4E;
+    --red-secondary: #FF8080;
 
     --grey00: #000;
     --grey10: #151B1F;

--- a/packages/react-components/src/styles/theme.ts
+++ b/packages/react-components/src/styles/theme.ts
@@ -129,7 +129,7 @@ export default css`
 
     &.ui.modal > .header:not(.ui),
     .ui.modal > .header:not(.ui) {
-      color: var(--grey90);
+      color: var(--grey80);
       font-weight: 300;
     }
 
@@ -155,7 +155,7 @@ export default css`
     }
 
     .ui.input>input {
-      color: var(--grey90);
+      color: var(--grey80);
     }
   }
 `;


### PR DESCRIPTION
Just some minor styling changes and adjustments.
<img width="1508" alt="Screenshot 2020-07-23 at 13 44 22" src="https://user-images.githubusercontent.com/7072141/88285650-c7d38680-ccef-11ea-9bc4-c0ec41d4774a.png">

Adjusted padding for sidebar menu items and hover styling
<img width="224" alt="Screenshot 2020-07-23 at 13 43 47" src="https://user-images.githubusercontent.com/7072141/88285685-d6ba3900-ccef-11ea-83f2-4f5690607b4e.png">

Adjusted padding for address selection and centring icon
<img width="580" alt="Screenshot 2020-07-23 at 13 44 54" src="https://user-images.githubusercontent.com/7072141/88285739-e9347280-ccef-11ea-9dc4-3985d1f15fae.png">

Removed extra vertical margin for input and adjusted styling for warning / error
<img width="589" alt="Screenshot 2020-07-23 at 13 44 46" src="https://user-images.githubusercontent.com/7072141/88285835-0ec17c00-ccf0-11ea-9e65-30ed7623b0d4.png">

InputFile focus
<img width="593" alt="Screenshot 2020-07-24 at 10 20 59" src="https://user-images.githubusercontent.com/7072141/88373368-045abd00-cd98-11ea-8722-dbd63f3c8bb6.png">

grey60 for root -> description text
<img width="576" alt="Screenshot 2020-07-23 at 13 44 59" src="https://user-images.githubusercontent.com/7072141/88285785-f94c5200-ccef-11ea-9683-5580fec69138.png">

Removed transition effect from HelpWidget. Brightest color value changed from grey90 to grey80. Added new reds.

