### PR TITLE
Clear old storage after purging old chain

### DIFF
--- a/packages/react-query/src/BlockAuthors.tsx
+++ b/packages/react-query/src/BlockAuthors.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { HeaderExtended } from '@polkadot/api-derive';
 import { useApi, useCall } from '@canvas-ui/react-hooks';
 import { formatNumber } from '@polkadot/util';
+import keyring from "@polkadot/ui-keyring";
 
 export interface Authors {
   byAuthor: Record<string, string>;
@@ -52,6 +53,22 @@ function BlockAuthorsBase ({ children }: Props): React.ReactElement<Props> {
           const blockNumber = lastHeader.number.unwrap();
           const thisBlockAuthor = lastHeader.author?.toString();
           const thisBlockNumber = formatNumber(blockNumber);
+
+          // @ts-ignore
+          const [currentBlockIndex] = blockNumber.words;
+          if (parseInt(window.localStorage.getItem('currentBlockIndex') || '0') > currentBlockIndex) {
+            const resetConfirm = confirm('It seems your currently running chain and the UI artifacts are out of sync.\n' +
+              '\n' +
+              'This can happen after purging a chain or switching the chain to another.\n' +
+              'If this is the case please click [OK] in order to reset your UI.')
+            if (resetConfirm) {
+              const existingContractList = keyring.getContracts()
+              existingContractList.forEach(existingContract => {
+                keyring.forgetContract(existingContract.address.toString());
+              })
+            }
+          }
+          window.localStorage.setItem('currentBlockIndex', currentBlockIndex);
 
           if (thisBlockAuthor) {
             byAuthor[thisBlockAuthor] = thisBlockNumber;

--- a/packages/react-query/src/BlockAuthors.tsx
+++ b/packages/react-query/src/BlockAuthors.tsx
@@ -53,14 +53,12 @@ function BlockAuthorsBase ({ children }: Props): React.ReactElement<Props> {
           const blockNumber = lastHeader.number.unwrap();
           const thisBlockAuthor = lastHeader.author?.toString();
           const thisBlockNumber = formatNumber(blockNumber);
-          const chainName = (await api.rpc.system.chain()).toString()
-          const systemName = (await api.rpc.system.version()).toString()
+          const chainName = (await api.rpc.system.chain()).toString();
 
           // @ts-ignore
           const [currentBlockIndex] = blockNumber.words;
           if (
-            ((window.localStorage.getItem('chainName') || chainName) !== chainName) ||
-            ((window.localStorage.getItem('systemName') || systemName) !== systemName) ||
+            chainName === 'Development' &&
             (parseInt(window.localStorage.getItem('currentBlockIndex') || '0') > currentBlockIndex)
           ) {
             const resetConfirm = confirm('It seems your currently running chain and the UI artifacts are out of sync.\n' +
@@ -75,8 +73,6 @@ function BlockAuthorsBase ({ children }: Props): React.ReactElement<Props> {
             }
           }
           window.localStorage.setItem('currentBlockIndex', currentBlockIndex);
-          window.localStorage.setItem('chainName', chainName);
-          window.localStorage.setItem('systemName', systemName);
 
           if (thisBlockAuthor) {
             byAuthor[thisBlockAuthor] = thisBlockNumber;

--- a/packages/react-query/src/BlockAuthors.tsx
+++ b/packages/react-query/src/BlockAuthors.tsx
@@ -48,15 +48,21 @@ function BlockAuthorsBase ({ children }: Props): React.ReactElement<Props> {
       }).catch(console.error);
 
       // subscribe to new headers
-      api.derive.chain.subscribeNewHeads((lastHeader): void => {
+      api.derive.chain.subscribeNewHeads(async (lastHeader): void => {
         if (lastHeader?.number) {
           const blockNumber = lastHeader.number.unwrap();
           const thisBlockAuthor = lastHeader.author?.toString();
           const thisBlockNumber = formatNumber(blockNumber);
+          const chainName = (await api.rpc.system.chain()).toString()
+          const systemName = (await api.rpc.system.version()).toString()
 
           // @ts-ignore
           const [currentBlockIndex] = blockNumber.words;
-          if (parseInt(window.localStorage.getItem('currentBlockIndex') || '0') > currentBlockIndex) {
+          if (
+            ((window.localStorage.getItem('chainName') || chainName) !== chainName) ||
+            ((window.localStorage.getItem('systemName') || systemName) !== systemName) ||
+            (parseInt(window.localStorage.getItem('currentBlockIndex') || '0') > currentBlockIndex)
+          ) {
             const resetConfirm = confirm('It seems your currently running chain and the UI artifacts are out of sync.\n' +
               '\n' +
               'This can happen after purging a chain or switching the chain to another.\n' +
@@ -69,6 +75,8 @@ function BlockAuthorsBase ({ children }: Props): React.ReactElement<Props> {
             }
           }
           window.localStorage.setItem('currentBlockIndex', currentBlockIndex);
+          window.localStorage.setItem('chainName', chainName);
+          window.localStorage.setItem('systemName', systemName);
 
           if (thisBlockAuthor) {
             byAuthor[thisBlockAuthor] = thisBlockNumber;


### PR DESCRIPTION
Issue #44

When running in local testing mode, a restart of the chain does not remove previous contracts. User should be notified that the contracts are out of sync and get an option to remove them.

I've added a basic update to localStorage which keeps track of the current block index. If the block index received from the node is smaller than the one in localStorage - it means that the chain has been restarted.

Let me know if this is acceptable, I'll change the `confirm` to a modal and add localization.