### PR TITLE
#18 Display contract events as notifications.

### DIFF
--- a/packages/react-components/src/Status/Queue.tsx
+++ b/packages/react-components/src/Status/Queue.tsx
@@ -10,6 +10,7 @@ import { createType } from '@polkadot/types';
 import { DispatchError } from '@polkadot/types/interfaces';
 import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
 import { ITuple, SignerPayloadJSON } from '@polkadot/types/types';
+import { u8aToString } from '@polkadot/util';
 
 import { BareProps } from '../types';
 import { STATUS_COMPLETE } from './constants';
@@ -56,7 +57,7 @@ function extractEvents (result?: SubmittableResult): ActionStatus[] {
       // filter events handled globally, or those we are not interested in, these are
       // handled by the global overview, so don't add them here
       .filter((record): boolean => !!record.event && record.event.section !== 'democracy')
-      .map(({ event: { data, method, section } }): ActionStatus => {
+      .map(({ event: { data, method, section }, topics }): ActionStatus => {
         if (section === 'system' && method === 'ExtrinsicFailed') {
           const [dispatchError] = data as unknown as ITuple<[DispatchError]>;
           let message = dispatchError.type;
@@ -76,6 +77,19 @@ function extractEvents (result?: SubmittableResult): ActionStatus[] {
             action: `${section}.${method}`,
             message,
             status: 'error'
+          };
+        }
+
+        if (section === 'contracts' && method === 'ContractExecution' && topics.length > 0) {
+          // find the name of the contract event. Needs improvement.
+          const message = topics.map(u8aToString)
+            .filter((topic: string) => topic.includes('::'))
+            ?.pop() ?? '';
+
+          return {
+            action: `${section}.${method}`,
+            message,
+            status: 'event'
           };
         }
 


### PR DESCRIPTION
Contract events will be shown as notifications on getting fired. Please suggest if there is any better way to get the name of the contract event from the event object. I have tested this with Flipper contract with a custom event and ERC20 contract.

![image](https://user-images.githubusercontent.com/10682672/106358395-de5b3a00-6331-11eb-8a4e-d5c72e02b16e.png)
