### PR TITLE
fix cyclic dep: moved two types down to react-hooks

### DIFF
--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -6,30 +6,6 @@ import { VoidFn } from '@canvas-ui/react-util/types';
 
 import { AnyJson } from '@polkadot/types/types';
 
-export interface AppNavigation {
-  instantiate: VoidFn;
-  instantiateAdd: VoidFn;
-  instantiateNew: (_?: string, __?: number) => VoidFn;
-  instantiateSuccess: (_: string) => VoidFn;
-  execute: VoidFn;
-  executeAdd: VoidFn;
-  executeCall: (_: string, __?: number) => VoidFn;
-  upload: VoidFn;
-  uploadSuccess: (_: string) => VoidFn;
-}
-
-export interface AppPaths {
-  instantiate: string;
-  instantiateAdd: string;
-  instantiateNew: (_?: string, __?: number) => string;
-  instantiateSuccess: (_: string) => string;
-  execute: string;
-  executeAdd: string;
-  executeCall: (_: string, __?: number) => string;
-  upload: string;
-  uploadSuccess: (_: string) => string;
-}
-
 interface CodeBase {
   id: string;
   codeHash: string;

--- a/packages/react-hooks/src/types.ts
+++ b/packages/react-hooks/src/types.ts
@@ -97,3 +97,27 @@ export interface UseEndpoints extends Endpoint {
   onChangeUrl: (_: string) => void;
   onChangeCustom: (_: boolean) => void;
 }
+
+export interface AppNavigation {
+  instantiate: VoidFn;
+  instantiateAdd: VoidFn;
+  instantiateNew: (_?: string, __?: number) => VoidFn;
+  instantiateSuccess: (_: string) => VoidFn;
+  execute: VoidFn;
+  executeAdd: VoidFn;
+  executeCall: (_: string, __?: number) => VoidFn;
+  upload: VoidFn;
+  uploadSuccess: (_: string) => VoidFn;
+}
+
+export interface AppPaths {
+  instantiate: string;
+  instantiateAdd: string;
+  instantiateNew: (_?: string, __?: number) => string;
+  instantiateSuccess: (_: string) => string;
+  execute: string;
+  executeAdd: string;
+  executeCall: (_: string, __?: number) => string;
+  upload: string;
+  uploadSuccess: (_: string) => string;
+}

--- a/packages/react-hooks/src/useAppNavigation.ts
+++ b/packages/react-hooks/src/useAppNavigation.ts
@@ -2,7 +2,7 @@
 // and @canvas-ui/app-execute authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AppNavigation, AppPaths } from '@canvas-ui/app/types';
+import type { AppNavigation, AppPaths } from './types';
 
 import { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';


### PR DESCRIPTION
This fixes just one remaining cyclic dependency which I overlooked by moving two type definitions down from @canvas-ui/app to @canvas-ui/react-hooks.