### PR TITLE
Display meaningfull error messages for failed contract calls

### DIFF
--- a/packages/page-execute/src/Outcome.tsx
+++ b/packages/page-execute/src/Outcome.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import { TypeRegistry } from '@polkadot/types';
 
 import { CallResult } from './types';
+import { ContractExecResultResult } from '@polkadot/types/interfaces';
 
 interface Props extends BareProps {
   onClear?: () => void;
@@ -17,7 +18,10 @@ interface Props extends BareProps {
   registry: TypeRegistry;
 }
 
+const retrieveErrorMessage = (result: ContractExecResultResult) => `Error: ${result?.asErr?.asModule['message']?.value?.toString()}`;
+
 function Outcome ({ className, onClear, outcome: { from, message, output, params, result, when }, registry }: Props): React.ReactElement<Props> | null {
+  const error = !result.isOk ? retrieveErrorMessage(result) : 'none';
   return (
     <div className={className}>
       <div className='info'>
@@ -41,6 +45,7 @@ function Outcome ({ className, onClear, outcome: { from, message, output, params
       </div>
       <Output
         isError={!result.isOk}
+        error={error}
         registry={registry}
         type={message.returnType}
         value={output}

--- a/packages/react-components/src/Data.tsx
+++ b/packages/react-components/src/Data.tsx
@@ -21,6 +21,7 @@ interface Props extends BareProps {
   registry?: Registry;
   type?: TypeDef;
   value?: AnyJson | null;
+  isError?:boolean;
 }
 
 const TRUNCATE_TO = 16;
@@ -42,9 +43,10 @@ function Field ({ name, value }: { name: string, value: React.ReactNode }): Reac
   );
 }
 
-function Data ({ asJson = false, className, registry = baseRegistry, type, value }: Props): React.ReactElement<Props> | null {
+function Data ({ asJson = false, className, registry = baseRegistry, type, value, isError }: Props): React.ReactElement<Props> | null {
   const content = useMemo(
     (): React.ReactNode => {
+      if(isError) return value;
       if (isNull(value) || (Array.isArray(value) && value.length === 0)) {
         return '()';
       }

--- a/packages/react-components/src/Output.tsx
+++ b/packages/react-components/src/Output.tsx
@@ -19,6 +19,7 @@ interface Props extends BareProps {
   children?: React.ReactNode;
   help?: React.ReactNode;
   isError?: boolean;
+  error?: string;
   isFull?: boolean;
   isHidden?: boolean;
   isMonospace?: boolean;
@@ -31,7 +32,7 @@ interface Props extends BareProps {
   withLabel?: boolean;
 }
 
-function Output ({ children, className = '', help, isError, isFull, isHidden, isTrimmed, label, registry, type, value, withCopy = false, withLabel }: Props): React.ReactElement<Props> {
+function Output ({ children, className = '', help, isError, isFull, isHidden, isTrimmed, label, registry, type, value, withCopy = false, withLabel, error='error' }: Props): React.ReactElement<Props> {
   return (
     <Labelled
       className={className}
@@ -46,7 +47,8 @@ function Output ({ children, className = '', help, isError, isFull, isHidden, is
           isTrimmed={isTrimmed}
           registry={registry}
           type={type}
-          value={value?.toJSON()}
+          isError= {isError}
+          value={isError ? error: value?.toJSON()}
         />
         {children}
         {withCopy


### PR DESCRIPTION
This is related to:

https://github.com/paritytech/canvas-ui/issues/95

I modified the Outcome component to display meaningful error messages as shown below:

![Canvas UI](https://user-images.githubusercontent.com/16603991/115859178-1a350580-a430-11eb-922c-d12426eb3fbf.png)

