### PR TITLE
Fixes for handling `Option` type

### DIFF
--- a/packages/react-components/src/Data.tsx
+++ b/packages/react-components/src/Data.tsx
@@ -114,7 +114,6 @@ function Data ({ asJson = false, className, registry = baseRegistry, type, value
         const subType = (type.sub as TypeDef[]).find(({ name }) => name === variant);
 
         if (asJson) {
-          
           return `${variant}: ${JSON.stringify(formatData(registry, subValue, subType).toJSON()) || '()'}`;
         }
 

--- a/packages/react-components/src/Data.tsx
+++ b/packages/react-components/src/Data.tsx
@@ -48,8 +48,6 @@ function Data ({ asJson = false, className, registry = baseRegistry, type, value
     (): React.ReactNode => {
       if (isError) return value;
 
-      if (isNull(value) || (Array.isArray(value) && value.length === 0)) {
-        return '()';
       try {
         const codec = formatData(registry, value, type);
 

--- a/packages/react-components/src/Data.tsx
+++ b/packages/react-components/src/Data.tsx
@@ -50,174 +50,177 @@ function Data ({ asJson = false, className, registry = baseRegistry, type, value
 
       if (isNull(value) || (Array.isArray(value) && value.length === 0)) {
         return '()';
-      }
+      try {
+        const codec = formatData(registry, value, type);
 
-      const codec = formatData(registry, value, type);
-
-      if (!type || type.displayName === 'Hash') {
-        return truncate(codec.toHex(), TRUNCATE_TO);
-      }
-
-      if (type.type === 'AccountId') {
-        return value
-          ? (
-            <AddressSmall
-              className='account-id'
-              value={value.toString()}
-            />
-          )
-          : null;
-      }
-
-      if (type.info === TypeDefInfo.Option && codec instanceof Option) {
-        const isSome = codec.isSome;
-        const subType = type.sub as TypeDef;
-
-        if (asJson) {
-          return `${isSome ? 'Some' : 'None'}${isSome ? `(${codec.unwrap().toString()})` : ''}`;
-        }
-
-        return (
-          <div className='enum'>
-            {isSome ? 'Some' : 'None'}
-            {isSome && (
-              <>
-                {'('}
-                <div className='inner'>
-                  <Data
-                    registry={registry}
-                    type={subType}
-                    value={codec.unwrap().toString()}
-                  />
-                </div>
-                {')'}
-              </>
-            )}
-          </div>
-        );
-      }
-
-      if (type.info === TypeDefInfo.Plain) {
-        return truncate(value?.toString() || '()', TRUNCATE_TO);
-      }
-
-      if (type.info === TypeDefInfo.Enum) {
-        const json = value as unknown as Record<string, AnyJson>;
-        const [variant, subValue] = Object.entries(json)[0];
-        const isNull = !!subValue && typeof subValue === 'object' && Object.entries(subValue)[0] === null;
-        const subType = (type.sub as TypeDef[]).find(({ name }) => name === variant);
-
-        if (asJson) {
-          return `${variant}: ${JSON.stringify(formatData(registry, subValue, subType).toJSON()) || '()'}`;
-        }
-
-        return (
-          <Labelled
-            isIndented
-            isSmall
-            withLabel={false}
-          >
-            <Field
-              key={variant}
-              name={variant}
-              value={
-                isNull
-                  ? Object.keys(subValue as Record<string, AnyJson>)[0]
-                  : <Data
-                    asJson
-                    registry={registry}
-                    type={subType}
-                    value={subValue}
-                  />
-              }
-            />
-          </Labelled>
-        );
-      }
-
-      if (type.info === TypeDefInfo.Struct) {
-        const struct = value as Record<string, AnyJson>;
-
-        if (asJson) {
-          return JSON.stringify(struct);
-        }
-
-        return (
-          <Labelled
-            isIndented
-            isSmall
-            withLabel={false}
-          >
-            {
-              Object.entries(struct).map(([key, field], index) => {
-                const subType = (type.sub as TypeDef[])[index];
-
-                return (
-                  <Field
-                    key={key}
-                    name={key}
-                    value={
-                      <Data
-                        asJson
-                        registry={registry}
-                        type={subType}
-                        value={formatData(registry, field, subType).toJSON()}
-                      />
-                    }
-                  />
-                );
-              })
-            }
-          </Labelled>
-        );
-      }
-
-      if (type.sub && [TypeDefInfo.Vec, TypeDefInfo.VecFixed].includes(type.info)) {
-        const sub = type.sub as TypeDef;
-
-        if (sub.type === 'u8') {
+        if (!type || type.displayName === 'Hash') {
           return truncate(codec.toHex(), TRUNCATE_TO);
         }
 
-        const array = codec.toJSON() as AnyJson[];
-
-        if (!Array.isArray(array)) {
-          return null;
+        if (type.type === 'AccountId') {
+          return value
+            ? (
+              <AddressSmall
+                className='account-id'
+                value={value.toString()}
+              />
+            )
+            : null;
         }
 
-        if (asJson) {
-          return JSON.stringify(array);
+        if (type.info === TypeDefInfo.Option && codec instanceof Option) {
+          const isSome = codec.isSome;
+          const subType = type.sub as TypeDef;
+
+          if (asJson) {
+            return `${isSome ? 'Some' : 'None'}${isSome ? `(${codec.unwrap().toString()})` : ''}`;
+          }
+
+          return (
+            <div className='enum'>
+              {isSome ? 'Some' : 'None'}
+              {isSome && (
+                <>
+                  {'('}
+                  <div className='inner'>
+                    <Data
+                      registry={registry}
+                      type={subType}
+                      value={codec.unwrap().toString()}
+                    />
+                  </div>
+                  {')'}
+                </>
+              )}
+            </div>
+          );
         }
 
-        return (
-          <Labelled
-            isIndented
-            isSmall
-            withLabel={false}
-          >
-            {
-              array.map((element, index) => {
-                return (
-                  <Field
-                    key={index}
-                    name={`${index}`}
-                    value={
-                      <Data
-                        asJson
-                        registry={registry}
-                        type={sub}
-                        value={element}
-                      />
-                    }
-                  />
-                );
-              })
-            }
-          </Labelled>
-        );
+        if (type.info === TypeDefInfo.Plain) {
+          return truncate(value?.toString() || '()', TRUNCATE_TO);
+        }
+
+        if (type.info === TypeDefInfo.Enum) {
+          const json = value as unknown as Record<string, AnyJson>;
+          const [variant, subValue] = Object.entries(json)[0];
+          const isNull = !!subValue && typeof subValue === 'object' && Object.entries(subValue)[0] === null;
+          const subType = (type.sub as TypeDef[]).find(({ name }) => name === variant);
+
+          if (asJson) {
+            return `${variant}: ${JSON.stringify(formatData(registry, subValue, subType).toJSON()) || '()'}`;
+          }
+
+          return (
+            <Labelled
+              isIndented
+              isSmall
+              withLabel={false}
+            >
+              <Field
+                key={variant}
+                name={variant}
+                value={
+                  isNull
+                    ? Object.keys(subValue as Record<string, AnyJson>)[0]
+                    : <Data
+                      asJson
+                      registry={registry}
+                      type={subType}
+                      value={subValue}
+                    />
+                }
+              />
+            </Labelled>
+          );
+        }
+
+        if (type.info === TypeDefInfo.Struct) {
+          const struct = value as Record<string, AnyJson>;
+
+          if (asJson) {
+            return JSON.stringify(struct);
+          }
+
+          return (
+            <Labelled
+              isIndented
+              isSmall
+              withLabel={false}
+            >
+              {
+                Object.entries(struct).map(([key, field], index) => {
+                  const subType = (type.sub as TypeDef[])[index];
+
+                  return (
+                    <Field
+                      key={key}
+                      name={key}
+                      value={
+                        <Data
+                          asJson
+                          registry={registry}
+                          type={subType}
+                          value={formatData(registry, field, subType).toJSON()}
+                        />
+                      }
+                    />
+                  );
+                })
+              }
+            </Labelled>
+          );
+        }
+
+        if (type.sub && [TypeDefInfo.Vec, TypeDefInfo.VecFixed].includes(type.info)) {
+          const sub = type.sub as TypeDef;
+
+          if (sub.type === 'u8') {
+            return truncate(codec.toHex(), TRUNCATE_TO);
+          }
+
+          const array = codec.toJSON() as AnyJson[];
+
+          if (!Array.isArray(array)) {
+            return null;
+          }
+
+          if (asJson) {
+            return JSON.stringify(array);
+          }
+
+          return (
+            <Labelled
+              isIndented
+              isSmall
+              withLabel={false}
+            >
+              {
+                array.map((element, index) => {
+                  return (
+                    <Field
+                      key={index}
+                      name={`${index}`}
+                      value={
+                        <Data
+                          asJson
+                          registry={registry}
+                          type={sub}
+                          value={element}
+                        />
+                      }
+                    />
+                  );
+                })
+              }
+            </Labelled>
+          );
+        }
+
+        return truncate(codec.toHex(), TRUNCATE_TO);
+      } catch (error) {
+        console.log(error);
+        return '()';
       }
-
-      return truncate(codec.toHex(), TRUNCATE_TO);
     },
     [asJson, isError, value, registry, type]
   );

--- a/packages/react-components/src/Data.tsx
+++ b/packages/react-components/src/Data.tsx
@@ -26,8 +26,8 @@ interface Props extends BareProps {
 
 const TRUNCATE_TO = 16;
 
-function formatData (registry: Registry, data: AnyJson, type: TypeDef | undefined): Codec {
-  return createTypeUnsafe(registry, type?.displayName || type?.type || 'Raw', [data]);
+function formatData (registry: Registry, data: AnyJson | null, type: TypeDef | undefined): Codec {
+  return createTypeUnsafe(registry, type?.type || type?.displayName || 'Raw', [data]);
 }
 
 function Field ({ name, value }: { name: string, value: React.ReactNode }): React.ReactElement {

--- a/packages/react-components/src/Data.tsx
+++ b/packages/react-components/src/Data.tsx
@@ -69,12 +69,12 @@ function Data ({ asJson = false, className, registry = baseRegistry, type, value
           : null;
       }
 
-      if (type.info === TypeDefInfo.Option && value instanceof Option) {
-        const isSome = value.isSome;
+      if (type.info === TypeDefInfo.Option && codec instanceof Option) {
+        const isSome = codec.isSome;
         const subType = type.sub as TypeDef;
 
         if (asJson) {
-          return `${isSome ? 'Some' : 'None'}${isSome ? `(${value.toString()})` : ''}`;
+          return `${isSome ? 'Some' : 'None'}${isSome ? `(${codec.unwrap().toString()})` : ''}`;
         }
 
         return (
@@ -87,7 +87,7 @@ function Data ({ asJson = false, className, registry = baseRegistry, type, value
                   <Data
                     registry={registry}
                     type={subType}
-                    value={value.toString()}
+                    value={codec.unwrap().toString()}
                   />
                 </div>
                 {')'}

--- a/packages/react-components/src/Data.tsx
+++ b/packages/react-components/src/Data.tsx
@@ -9,7 +9,8 @@ import styled from 'styled-components';
 
 import { createTypeUnsafe, Option } from '@polkadot/types';
 import { AnyJson, Codec, Registry, TypeDef, TypeDefInfo } from '@polkadot/types/types';
-import { isNull } from '@polkadot/util';
+import { Null } from '@polkadot/types/primitive';
+import { isInstanceOf } from '@polkadot/util';
 
 import AddressSmall from './AddressMini';
 import Labelled from './Labelled';
@@ -27,7 +28,12 @@ interface Props extends BareProps {
 const TRUNCATE_TO = 16;
 
 function formatData (registry: Registry, data: AnyJson | null, type: TypeDef | undefined): Codec {
-  return createTypeUnsafe(registry, type?.type || type?.displayName || 'Raw', [data]);
+  try {
+    return createTypeUnsafe(registry, type?.type || type?.displayName || 'Raw', [data]);
+  } catch (error) {
+    console.log(error);
+    return new Null(registry);
+  }
 }
 
 function Field ({ name, value }: { name: string, value: React.ReactNode }): React.ReactElement {
@@ -48,177 +54,177 @@ function Data ({ asJson = false, className, registry = baseRegistry, type, value
     (): React.ReactNode => {
       if (isError) return value;
 
-      try {
-        const codec = formatData(registry, value, type);
+      const codec = formatData(registry, value, type);
 
-        if (!type || type.displayName === 'Hash') {
+      if (isInstanceOf(codec, Null)) {
+        return '()';
+      }
+
+      if (!type || type.displayName === 'Hash') {
+        return truncate(codec.toHex(), TRUNCATE_TO);
+      }
+
+      if (type.type === 'AccountId') {
+        return value
+          ? (
+            <AddressSmall
+              className='account-id'
+              value={value.toString()}
+            />
+          )
+          : null;
+      }
+
+      if (type.info === TypeDefInfo.Option && codec instanceof Option) {
+        const isSome = codec.isSome;
+        const subType = type.sub as TypeDef;
+
+        if (asJson) {
+          return `${isSome ? 'Some' : 'None'}${isSome ? `(${codec.unwrap().toString()})` : ''}`;
+        }
+
+        return (
+          <div className='enum'>
+            {isSome ? 'Some' : 'None'}
+            {isSome && (
+              <>
+                {'('}
+                <div className='inner'>
+                  <Data
+                    registry={registry}
+                    type={subType}
+                    value={codec.unwrap().toString()}
+                  />
+                </div>
+                {')'}
+              </>
+            )}
+          </div>
+        );
+      }
+
+      if (type.info === TypeDefInfo.Plain) {
+        return truncate(value?.toString() || '()', TRUNCATE_TO);
+      }
+
+      if (type.info === TypeDefInfo.Enum) {
+        const json = value as unknown as Record<string, AnyJson>;
+        const [variant, subValue] = Object.entries(json)[0];
+        const isNull = !!subValue && typeof subValue === 'object' && Object.entries(subValue)[0] === null;
+        const subType = (type.sub as TypeDef[]).find(({ name }) => name === variant);
+
+        if (asJson) {
+          
+          return `${variant}: ${JSON.stringify(formatData(registry, subValue, subType).toJSON()) || '()'}`;
+        }
+
+        return (
+          <Labelled
+            isIndented
+            isSmall
+            withLabel={false}
+          >
+            <Field
+              key={variant}
+              name={variant}
+              value={
+                isNull
+                  ? Object.keys(subValue as Record<string, AnyJson>)[0]
+                  : <Data
+                    asJson
+                    registry={registry}
+                    type={subType}
+                    value={subValue}
+                  />
+              }
+            />
+          </Labelled>
+        );
+      }
+
+      if (type.info === TypeDefInfo.Struct) {
+        const struct = value as Record<string, AnyJson>;
+
+        if (asJson) {
+          return JSON.stringify(struct);
+        }
+
+        return (
+          <Labelled
+            isIndented
+            isSmall
+            withLabel={false}
+          >
+            {
+              Object.entries(struct).map(([key, field], index) => {
+                const subType = (type.sub as TypeDef[])[index];
+
+                return (
+                  <Field
+                    key={key}
+                    name={key}
+                    value={
+                      <Data
+                        asJson
+                        registry={registry}
+                        type={subType}
+                        value={formatData(registry, field, subType).toJSON()}
+                      />
+                    }
+                  />
+                );
+              })
+            }
+          </Labelled>
+        );
+      }
+
+      if (type.sub && [TypeDefInfo.Vec, TypeDefInfo.VecFixed].includes(type.info)) {
+        const sub = type.sub as TypeDef;
+
+        if (sub.type === 'u8') {
           return truncate(codec.toHex(), TRUNCATE_TO);
         }
 
-        if (type.type === 'AccountId') {
-          return value
-            ? (
-              <AddressSmall
-                className='account-id'
-                value={value.toString()}
-              />
-            )
-            : null;
+        const array = codec.toJSON() as AnyJson[];
+
+        if (!Array.isArray(array)) {
+          return null;
         }
 
-        if (type.info === TypeDefInfo.Option && codec instanceof Option) {
-          const isSome = codec.isSome;
-          const subType = type.sub as TypeDef;
-
-          if (asJson) {
-            return `${isSome ? 'Some' : 'None'}${isSome ? `(${codec.unwrap().toString()})` : ''}`;
-          }
-
-          return (
-            <div className='enum'>
-              {isSome ? 'Some' : 'None'}
-              {isSome && (
-                <>
-                  {'('}
-                  <div className='inner'>
-                    <Data
-                      registry={registry}
-                      type={subType}
-                      value={codec.unwrap().toString()}
-                    />
-                  </div>
-                  {')'}
-                </>
-              )}
-            </div>
-          );
+        if (asJson) {
+          return JSON.stringify(array);
         }
 
-        if (type.info === TypeDefInfo.Plain) {
-          return truncate(value?.toString() || '()', TRUNCATE_TO);
-        }
-
-        if (type.info === TypeDefInfo.Enum) {
-          const json = value as unknown as Record<string, AnyJson>;
-          const [variant, subValue] = Object.entries(json)[0];
-          const isNull = !!subValue && typeof subValue === 'object' && Object.entries(subValue)[0] === null;
-          const subType = (type.sub as TypeDef[]).find(({ name }) => name === variant);
-
-          if (asJson) {
-            return `${variant}: ${JSON.stringify(formatData(registry, subValue, subType).toJSON()) || '()'}`;
-          }
-
-          return (
-            <Labelled
-              isIndented
-              isSmall
-              withLabel={false}
-            >
-              <Field
-                key={variant}
-                name={variant}
-                value={
-                  isNull
-                    ? Object.keys(subValue as Record<string, AnyJson>)[0]
-                    : <Data
-                      asJson
-                      registry={registry}
-                      type={subType}
-                      value={subValue}
-                    />
-                }
-              />
-            </Labelled>
-          );
-        }
-
-        if (type.info === TypeDefInfo.Struct) {
-          const struct = value as Record<string, AnyJson>;
-
-          if (asJson) {
-            return JSON.stringify(struct);
-          }
-
-          return (
-            <Labelled
-              isIndented
-              isSmall
-              withLabel={false}
-            >
-              {
-                Object.entries(struct).map(([key, field], index) => {
-                  const subType = (type.sub as TypeDef[])[index];
-
-                  return (
-                    <Field
-                      key={key}
-                      name={key}
-                      value={
-                        <Data
-                          asJson
-                          registry={registry}
-                          type={subType}
-                          value={formatData(registry, field, subType).toJSON()}
-                        />
-                      }
-                    />
-                  );
-                })
-              }
-            </Labelled>
-          );
-        }
-
-        if (type.sub && [TypeDefInfo.Vec, TypeDefInfo.VecFixed].includes(type.info)) {
-          const sub = type.sub as TypeDef;
-
-          if (sub.type === 'u8') {
-            return truncate(codec.toHex(), TRUNCATE_TO);
-          }
-
-          const array = codec.toJSON() as AnyJson[];
-
-          if (!Array.isArray(array)) {
-            return null;
-          }
-
-          if (asJson) {
-            return JSON.stringify(array);
-          }
-
-          return (
-            <Labelled
-              isIndented
-              isSmall
-              withLabel={false}
-            >
-              {
-                array.map((element, index) => {
-                  return (
-                    <Field
-                      key={index}
-                      name={`${index}`}
-                      value={
-                        <Data
-                          asJson
-                          registry={registry}
-                          type={sub}
-                          value={element}
-                        />
-                      }
-                    />
-                  );
-                })
-              }
-            </Labelled>
-          );
-        }
-
-        return truncate(codec.toHex(), TRUNCATE_TO);
-      } catch (error) {
-        console.log(error);
-        return '()';
+        return (
+          <Labelled
+            isIndented
+            isSmall
+            withLabel={false}
+          >
+            {
+              array.map((element, index) => {
+                return (
+                  <Field
+                    key={index}
+                    name={`${index}`}
+                    value={
+                      <Data
+                        asJson
+                        registry={registry}
+                        type={sub}
+                        value={element}
+                      />
+                    }
+                  />
+                );
+              })
+            }
+          </Labelled>
+        );
       }
+
+      return truncate(codec.toHex(), TRUNCATE_TO);
     },
     [asJson, isError, value, registry, type]
   );


### PR DESCRIPTION
This PR addresses the issue raised in #52 by implementing the change proposed by @achimcc.
Implementing this fix revealed the additional incorrect behaviour in handling `Option` types mentioned in #52.

The three major changes in this PR are

1. Prefer `type.type` over `type.displayName` in `formatData`
2. Use `codec` instead of `value` when checking for an `Option` type. Use `codec.isSome` and `codec.unwrap`.
3. Remove the check for `null` and and empty array at the start of `Data` and instead let `createTypeUnsafe` handle any issues and throw an exception. Catch and return `()` in case of any exception.

Apologies in advance for the large number of lines changed. The bulk of these changes are due to an extra level of indentation as a result of the try-catch. Any feedback on how to do this more cleanly would be greatly appreciated.